### PR TITLE
Do not submit code coverage for the first build stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,7 @@ notifications:
 
 script: julia --code-coverage --inline=no -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
 
-after_success:
-  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+
 
 ## Important note:
 ## If you want to run the integration tests, make sure that you go into the
@@ -45,11 +44,9 @@ jobs:
       env:
         - COMPATHELPER_RUN_INTEGRATION_TESTS="true"
       julia: "1.2" # current stable release
+      after_success: julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
     - stage: CompatHelper Integration Tests
       env:
         - COMPATHELPER_RUN_INTEGRATION_TESTS="true"
       julia: "1.3" # next release
-#     - stage: CompatHelper Integration Tests
-#       env:
-#         - COMPATHELPER_RUN_INTEGRATION_TESTS="true"
-#       julia: "1.4" # this doesn't exist yet
+      after_success: julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ env:
     - JULIA_DEBUG="all"
 
 julia:
-  - "1.2" # current stable release
-  - "1.3" # next release
+  - "1.2"
+  - "1.3"
 
 language: julia
 
@@ -43,10 +43,10 @@ jobs:
     - stage: CompatHelper Integration Tests
       env:
         - COMPATHELPER_RUN_INTEGRATION_TESTS="true"
-      julia: "1.2" # current stable release
+      julia: "1.2"
       after_success: julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
     - stage: CompatHelper Integration Tests
       env:
         - COMPATHELPER_RUN_INTEGRATION_TESTS="true"
-      julia: "1.3" # next release
+      julia: "1.3"
       after_success: julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'


### PR DESCRIPTION
There are two build stages.

The first build stage only runs the unit tests. It works on PRs made from within this repo, as well as PRs made from forked repos.

The second build stage runs both the unit tests and the integration tests. It only works on PRs made from within this repo. It does not work on PRs made from forked repos.

There is no point in submitting code coverage reports from the first build stage. We should only submit coverage from the second build stage.