### PR TITLE
Simplify the Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ branches:
 env:
   global:
     - COMPATHELPER_INTEGRATION_TEST_REPO="bcbi-test/compathelper_integration_test_repo.jl"
+    - COMPATHELPER_RUN_INTEGRATION_TESTS="true"
     - JULIA_DEBUG="all"
 
 julia:
@@ -28,25 +29,12 @@ matrix:
 notifications:
   email: false
 
-script: julia --code-coverage --inline=no -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
-
-
-
 ## Important note:
 ## If you want to run the integration tests, make sure that you go into the
 ## Travis settings for your repository, enable the "Limit concurrent jobs"
 ## option, and set the number of concurrent jobs to one (1).
 ## For more details, see https://docs.travis-ci.com/user/customizing-the-build/#limiting-concurrent-jobs
 
-jobs:
-  include:
-    - stage: CompatHelper Integration Tests
-      env:
-        - COMPATHELPER_RUN_INTEGRATION_TESTS="true"
-      julia: "1.2"
-      after_success: julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
-    - stage: CompatHelper Integration Tests
-      env:
-        - COMPATHELPER_RUN_INTEGRATION_TESTS="true"
-      julia: "1.3"
-      after_success: julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+script: julia --code-coverage --inline=no -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
+
+after_success: julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'


### PR DESCRIPTION
Currently, we have two build stages:
1. The first build stage runs only the unit tests.
2. The second build stage runs both the unit tests and the integration tests. This build stage requires a secret Travis environment variable.

Because we are using Bors, both build stages work on all PRs, whether the PR is from within this repo or from a fork.

Therefore, there is really no need to have these two stages. We can just have one build stage that runs both the unit tests and the integration tests.