### PR TITLE
Update manifests by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,24 +32,23 @@ CompatHelper is now installed as a GitHub Action on your repository.
 * Open the specific repository, navigate to the Settings tab, click Actions option, check if the Actions is enabled for this repository.
 
 
-## Updating `Manifest.toml` files after updating compat information
+## Custom pre-commit hooks
 
-If you check in `Manifest.toml` file(s), the PR created by default CompatHelper setup does not run CI with the latest versions of the dependencies.  In this case, it may be a good idea to run `Pkg.update()` via CompatHelper.  This can be done simply using the following snippet instead `run: julia -e 'using CompatHelper; CompatHelper.main()'`:
+CompatHelper supports running a custom function just before commiting changes.
+By default, this function updates any `Manifest.toml` files in your repository to reflect new compatibility bounds.
+If you want to extend this behaviour, you can pass your own zero-argument function to `CompatHelper.main`, like so:
 
 ```yaml
-run: >-
-  julia -e '
+run: julia -e '
   using CompatHelper;
   CompatHelper.main() do;
-      run(`julia --project=test -e "import Pkg; Pkg.instantiate(); Pkg.update()"`);
-      run(`julia --project=docs -e "import Pkg; Pkg.instantiate(); Pkg.update()"`);
-  end
-  '
+    CompatHelper.update_environments();
+    println("I did it!")
+  end;'
 ```
 
-This setup updates `test/Manifest.toml` and `docs/Manifest.toml` before CompatHelper creates a commit for the pull request.
-
-This snippet uses `>-` to specify a long one-liner command using multi-line code (i.e., the shell does not see the newline characters after `;`).  Note that every line must ends with `;` when using `>-`.  Do not use `'` inside (outer) Julia code since it is used to quote the command line option `-e '...'`.
+This snippet uses `;` to specify the ends of lines, because according to YAML, the entire block of Julia code is a single line.
+Also to note is that you cannot use `'` inside of your Julia command, since it's used to quote the Julia code.
 
 A full example is available here: https://github.com/tkf/Kaleido.jl/blob/master/.github/workflows/CompatHelper.yml
 

--- a/test/templates/manifests/Manifest.toml
+++ b/test/templates/manifests/Manifest.toml
@@ -1,0 +1,39 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[Example]]
+deps = ["Test"]
+git-tree-sha1 = "8eb7b4d4ca487caade9ba3e85932e28ce6d6e1f8"
+uuid = "7876af07-990d-54b4-ab0e-23690620f79a"
+version = "0.5.1"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/templates/manifests/Project.toml
+++ b/test/templates/manifests/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+
+[compat]
+Example = "0.5.3"

--- a/test/templates/manifests/README.md
+++ b/test/templates/manifests/README.md
@@ -1,0 +1,2 @@
+Please do not update the manifests in this directory!
+They are out of date on purpose.

--- a/test/templates/manifests/a/b/Manifest.toml
+++ b/test/templates/manifests/a/b/Manifest.toml
@@ -1,0 +1,39 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[Example]]
+deps = ["Test"]
+git-tree-sha1 = "8eb7b4d4ca487caade9ba3e85932e28ce6d6e1f8"
+uuid = "7876af07-990d-54b4-ab0e-23690620f79a"
+version = "0.5.1"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/templates/manifests/a/b/Project.toml
+++ b/test/templates/manifests/a/b/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+
+[compat]
+Example = "0.5.3"

--- a/test/templates/manifests/a/b/c/Manifest.toml
+++ b/test/templates/manifests/a/b/c/Manifest.toml
@@ -1,0 +1,39 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[Example]]
+deps = ["Test"]
+git-tree-sha1 = "8eb7b4d4ca487caade9ba3e85932e28ce6d6e1f8"
+uuid = "7876af07-990d-54b4-ab0e-23690620f79a"
+version = "0.5.1"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/templates/manifests/a/b/c/Project.toml
+++ b/test/templates/manifests/a/b/c/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+
+[compat]
+Example = "0.5.3"


### PR DESCRIPTION
This finds all Manifest.toml files, activates their environments, and runs `Pkg.update`. 
There is a platform-specific `find` invocation in there, I suppose it should probably go away if we have something like #85. It could be implemented instead with `walkdir` or Glob.jl (although https://github.com/vtjnash/Glob.jl/issues/19 is needed).
