### PR TITLE
update to Pkg v1.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CompatHelper"
 uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Brown Center for Biomedical Informatics"]
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/stdlib.jl
+++ b/src/stdlib.jl
@@ -1,7 +1,15 @@
 import UUIDs
 
+if VERSION < v"1.4"
+    stdlibs = Pkg.Types.stdlib
+else
+    # renamed to stdlibs
+    # https://github.com/JuliaLang/Pkg.jl/pull/1559
+    stdlibs = Pkg.Types.stdlibs
+end
+
 # This function is based off of a similar function here:
 # https://github.com/JuliaRegistries/RegistryCI.jl/blob/master/src/RegistryCI.jl
 function gather_stdlib_uuids()
-    return Set{UUIDs.UUID}(x for x in keys(Pkg.Types.stdlib()))
+    return Set{UUIDs.UUID}(x for x in keys(stdlibs()))
 end


### PR DESCRIPTION
I think I've mistakenly set the julia version to `"1"` and thus runs the latest 1.4.0 version, which isn't compatible to CompatHelper yet, and get tens of github action error notifications.

An example can be found here: https://github.com/JuliaImages/ImageContrastAdjustment.jl/runs/526166418?check_suite_focus=true

I'm not sure if this fixes all the things, is there a way to run CompatHelper locally? (Looks like not)