### PR TITLE
GitHub Enterprise Support 2: Electric Boogaloo

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CompatHelper"
 uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Brown Center for Biomedical Informatics"]
-version = "1.11.0"
+version = "1.12.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/get_project_deps.jl
+++ b/src/get_project_deps.jl
@@ -1,11 +1,16 @@
 import GitHub
 import Pkg
 
-function get_project_deps(api::GitHub.GitHubAPI, repo::GitHub.Repo; auth::GitHub.Authorization, master_branch::Union{DefaultBranch, AbstractString}, subdir::AbstractString)
+function get_project_deps(api::GitHub.GitHubAPI,
+                          clone_hostname::HostnameForClones,
+                          repo::GitHub.Repo;
+                          auth::GitHub.Authorization,
+                          master_branch::Union{DefaultBranch, AbstractString},
+                          subdir::AbstractString)
     original_directory = pwd()
     tmp_dir = mktempdir()
     atexit(() -> rm(tmp_dir; force = true, recursive = true))
-    url_with_auth = "https://x-access-token:$(auth.token)@$(api.endpoint.host)/$(repo.full_name).git"
+    url_with_auth = "https://x-access-token:$(auth.token)@$(clone_hostname.hostname)/$(repo.full_name).git"
     cd(tmp_dir)
     try
         run(`git clone $(url_with_auth) REPO`)

--- a/src/get_project_deps.jl
+++ b/src/get_project_deps.jl
@@ -1,11 +1,11 @@
 import GitHub
 import Pkg
 
-function get_project_deps(repo::GitHub.Repo; auth::GitHub.Authorization, master_branch::Union{DefaultBranch, AbstractString}, subdir::AbstractString)
+function get_project_deps(api::GitHub.GitHubAPI, repo::GitHub.Repo; auth::GitHub.Authorization, master_branch::Union{DefaultBranch, AbstractString}, subdir::AbstractString)
     original_directory = pwd()
     tmp_dir = mktempdir()
     atexit(() -> rm(tmp_dir; force = true, recursive = true))
-    url_with_auth = "https://x-access-token:$(auth.token)@github.com/$(repo.full_name).git"
+    url_with_auth = "https://x-access-token:$(auth.token)@$(api.endpoint.host)/$(repo.full_name).git"
     cd(tmp_dir)
     try
         run(`git clone $(url_with_auth) REPO`)

--- a/src/main.jl
+++ b/src/main.jl
@@ -1,6 +1,6 @@
 import Pkg
-using HTTP
-using GitHub
+import HTTP
+import GitHub
 
 const default_registries = Pkg.Types.RegistrySpec[Pkg.RegistrySpec(name = "General",
                                                                    uuid = "23338594-aafe-5451-b93e-139f81909106",

--- a/src/main.jl
+++ b/src/main.jl
@@ -32,7 +32,6 @@ function main(precommit_hook::Function = update_manifests,
     repo = GitHub.repo(api, GITHUB_REPOSITORY; auth = auth)
 
     _all_open_prs = get_all_pull_requests(api,
-                                          clone_hostname,
                                           repo,
                                           "open";
                                           auth = auth)

--- a/src/main.jl
+++ b/src/main.jl
@@ -24,10 +24,10 @@ function main(precommit_hook::Function = update_manifests,
     @info("Environment variable `COMPATHELPER_PRIV` is defined, is nonempty, and is not the string `false`: $(COMPATHELPER_PRIV_is_defined)")
 
     api = GitHub.GitHubWebAPI(HTTP.URI(api_url))
-    env["GITHUB_TOKEN"] = github_token(ci_cfg; env = env)
-    env["GITHUB_REPOSITORY"] = replace(github_repository(ci_cfg; env = env), ".git"=>"")   # small fix to normalize it
-    auth = GitHub.authenticate(api, env["GITHUB_TOKEN"])
-    repo = GitHub.repo(api, env["GITHUB_REPOSITORY"]; auth = auth)
+    GITHUB_TOKEN = github_token(ci_cfg; env = ENV)
+    GITHUB_REPOSITORY = github_repository(ci_cfg; env = ENV)
+    auth = GitHub.authenticate(api, GITHUB_TOKEN)
+    repo = GitHub.repo(api, GITHUB_REPOSITORY; auth = auth)
 
     _all_open_prs = get_all_pull_requests(api, repo, "open"; auth = auth)
     _nonforked_prs = exclude_pull_requests_from_forks(repo, _all_open_prs)

--- a/src/main.jl
+++ b/src/main.jl
@@ -31,7 +31,11 @@ function main(precommit_hook::Function = update_manifests,
     auth = GitHub.authenticate(api, GITHUB_TOKEN)
     repo = GitHub.repo(api, GITHUB_REPOSITORY; auth = auth)
 
-    _all_open_prs = get_all_pull_requests(api, repo, "open"; auth = auth)
+    _all_open_prs = get_all_pull_requests(api,
+                                          clone_hostname,
+                                          repo,
+                                          "open";
+                                          auth = auth)
     _nonforked_prs = exclude_pull_requests_from_forks(repo, _all_open_prs)
     my_username = get_my_username(ci_cfg; auth = auth, env = env)
     pr_list = only_my_pull_requests(_nonforked_prs; my_username = my_username)
@@ -54,6 +58,7 @@ function main(precommit_hook::Function = update_manifests,
                                             registries)
 
         make_pr_for_new_version(api,
+                                clone_hostname,
                                 precommit_hook,
                                 repo,
                                 dep_to_current_compat_entry,

--- a/src/new_versions.jl
+++ b/src/new_versions.jl
@@ -189,6 +189,7 @@ end
 end
 
 function make_pr_for_new_version(api::GitHub.GitHubAPI,
+                                 clone_hostname::HostnameForClones,
                                  precommit_hook::Function,
                                  compat_entry_for_latest_version::String,
                                  new_compat_entry::String,
@@ -274,8 +275,8 @@ function make_pr_for_new_version(api::GitHub.GitHubAPI,
     if new_pr_title in pr_titles
         @info("An open PR with the title already exists", new_pr_title)
     else
-        url_with_auth = "https://x-access-token:$(auth.token)@$(api.endpoint.host)/$(repo.full_name).git"
-        url_for_ssh = "git@$(api.endpoint.host):$(repo.full_name).git"
+        url_with_auth = "https://x-access-token:$(auth.token)@$(clone_hostname.hostname)/$(repo.full_name).git"
+        url_for_ssh = "git@$(clone_hostname.hostname):$(repo.full_name).git"
 
         tmp_dir = mktempdir()
         atexit(() -> rm(tmp_dir; force = true, recursive = true))

--- a/src/new_versions.jl
+++ b/src/new_versions.jl
@@ -2,6 +2,7 @@ import GitHub
 import Pkg
 
 function make_pr_for_new_version(api::GitHub.GitHubAPI,
+                                 clone_hostname::HostnameForClones,
                                  precommit_hook::Function,
                                  repo::GitHub.Repo,
                                  dep_to_current_compat_entry::Dict{Package, Union{Pkg.Types.VersionSpec, Nothing}},
@@ -23,6 +24,7 @@ function make_pr_for_new_version(api::GitHub.GitHubAPI,
     always_assert(keep_existing_compat || drop_existing_compat)
     for dep in keys(dep_to_current_compat_entry)
         make_pr_for_new_version(api,
+                                clone_hostname,
                                 precommit_hook,
                                 repo,
                                 dep,
@@ -46,6 +48,7 @@ function make_pr_for_new_version(api::GitHub.GitHubAPI,
 end
 
 function make_pr_for_new_version(api::GitHub.GitHubAPI,
+                                 clone_hostname::HostnameForClones,
                                  precommit_hook::Function,
                                  repo::GitHub.Repo,
                                  dep::Package,
@@ -88,6 +91,7 @@ function make_pr_for_new_version(api::GitHub.GitHubAPI,
                                                         compat_entry_for_latest_version,
                                                         :brandnewentry)
             make_pr_for_new_version(api,
+                                    clone_hostname,
                                     precommit_hook,
                                     compat_entry_for_latest_version,
                                     brand_new_compat,
@@ -113,6 +117,7 @@ function make_pr_for_new_version(api::GitHub.GitHubAPI,
                                                        compat_entry_for_latest_version,
                                                        :drop)
                 make_pr_for_new_version(api,
+                                        clone_hostname,
                                         precommit_hook,
                                         compat_entry_for_latest_version,
                                         drop_compat,
@@ -138,6 +143,7 @@ function make_pr_for_new_version(api::GitHub.GitHubAPI,
                                                        compat_entry_for_latest_version,
                                                        :keep)
                 make_pr_for_new_version(api,
+                                        clone_hostname,
                                         precommit_hook,
                                         compat_entry_for_latest_version,
                                         keep_compat,

--- a/src/pull_requests.jl
+++ b/src/pull_requests.jl
@@ -1,6 +1,7 @@
 import GitHub
 
-function get_all_pull_requests(repo::GitHub.Repo,
+function get_all_pull_requests(api::GitHub.GitHubAPI,
+                               repo::GitHub.Repo,
                                state::String;
                                auth::GitHub.Authorization,
                                per_page::Integer = 100,
@@ -9,13 +10,13 @@ function get_all_pull_requests(repo::GitHub.Repo,
     myparams = Dict("state" => state,
                     "per_page" => per_page,
                     "page" => 1)
-    prs, page_data = GitHub.pull_requests(repo;
+    prs, page_data = GitHub.pull_requests(api, repo;
                                           auth=auth,
                                           params = myparams,
                                           page_limit = page_limit)
     append!(all_pull_requests, prs)
     while haskey(page_data, "next")
-        prs, page_data = GitHub.pull_requests(repo;
+        prs, page_data = GitHub.pull_requests(api, repo;
                                               auth=auth,
                                               page_limit = page_limit,
                                               start_page = page_data["next"])
@@ -68,7 +69,8 @@ function only_my_pull_requests(pr_list::Vector{GitHub.PullRequest}; my_username:
     return my_pr_list
 end
 
-function create_new_pull_request(repo::GitHub.Repo;
+function create_new_pull_request(api::GitHub.GitHubAPI,
+                                 repo::GitHub.Repo;
                                  base_branch::String,
                                  head_branch::String,
                                  title::String,
@@ -79,6 +81,6 @@ function create_new_pull_request(repo::GitHub.Repo;
     params["head"] = head_branch
     params["base"] = base_branch
     params["body"] = body
-    result = GitHub.create_pull_request(repo; params = params, auth = auth)
+    result = GitHub.create_pull_request(api, repo; params = params, auth = auth)
     return result
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -21,6 +21,10 @@ struct GitHubActions <: CIService
     username::String
 end
 
+struct HostnameForClones
+    hostname::String
+end
+
 struct MajorMinorVersion
     major::Base.VInt
     minor::Base.VInt

--- a/test/integration-tests.jl
+++ b/test/integration-tests.jl
@@ -12,6 +12,7 @@ whoami = username(auth)
 repo_url_without_auth = "https://github.com/$(COMPATHELPER_INTEGRATION_TEST_REPO)"
 repo_url_with_auth = "https://$(whoami):$(TEST_USER_GITHUB_TOKEN)@github.com/$(COMPATHELPER_INTEGRATION_TEST_REPO)"
 repo = GitHub.repo(COMPATHELPER_INTEGRATION_TEST_REPO; auth = auth)
+api = GitHub.GitHubWebAPI(HTTP.URI("https://api.github.com"))
 Test.@test success(`git --version`)
 @info("Authenticated to GitHub as \"$(whoami)\"")
 
@@ -120,7 +121,7 @@ with_master_branch(templates("master_6"), "master"; repo_url = repo_url_with_aut
     end
 end
 
-all_prs = CompatHelper.get_all_pull_requests(repo, "open";
+all_prs = CompatHelper.get_all_pull_requests(api, repo, "open";
                                              auth = auth,
                                              per_page = 3,
                                              page_limit = 3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ import Base64
 import CompatHelper
 import Dates
 import GitHub
+import HTTP
 import JSON
 import Pkg
 import Printf


### PR DESCRIPTION
Fixes #208 
Closes #221 

- Passing github base url as parameter.
- Removing hardcoded github.com from some places.