### PR TITLE
Add the `workflow_dispatch` trigger: this allows users to manually trigger CompatHelper at any time

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -3,6 +3,7 @@ name: CompatHelper
 on:
   schedule:
     - cron: '00 00 * * *'
+  workflow_dispatch:
 
 jobs:
   CompatHelper:

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -2,6 +2,7 @@ name: TagBot
 on:
   schedule:
     - cron: 0 0 * * *
+  workflow_dispatch:
 jobs:
   TagBot:
     runs-on: ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CompatHelper"
 uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Brown Center for Biomedical Informatics"]
-version = "1.13.2"
+version = "1.13.3"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/README.md
+++ b/README.md
@@ -32,11 +32,10 @@ CompatHelper is maintained by the Brown Center for Biomedical Informatics (BCBI)
 Create a file at `.github/workflows/CompatHelper.yml` with the following contents:
 ```yaml
 name: CompatHelper
-
 on:
   schedule:
     - cron: '00 00 * * *'
-
+  workflow_dispatch:
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Thus, users don't need to wait 24 hours for the next CompatHelper run.